### PR TITLE
bump embedded-svc to 0.26

### DIFF
--- a/edge-frame/Cargo.toml
+++ b/edge-frame/Cargo.toml
@@ -37,7 +37,7 @@ enumset = { version = "1", default-features = false, optional = true, features =
 strum = { version = "0.23", default-features = false, optional = true, features = ["derive"] }
 strum_macros = { version = "0.23", optional = true }
 num_enum = { version = "0.5", default-features = false, optional = true }
-embedded-svc = { version = "0.25", optional = true, default-features = false, features = ["use_serde", "use_strum", "use_numenum"] }
+embedded-svc = { version = "0.26", optional = true, default-features = false, features = ["use_serde", "use_strum", "use_numenum"] }
 flate2 = { version = "1", optional = true }
 
 # middleware-ws


### PR DESCRIPTION
this needs a bump or it collides with the recently updated `esp-idf-scv`